### PR TITLE
Properly escape newlines in failure messages

### DIFF
--- a/lib/minitest/ci.rb
+++ b/lib/minitest/ci.rb
@@ -105,7 +105,7 @@ module Minitest
           bt    = Minitest::filter_backtrace failure.backtrace
 
           xml << "    <%s type='%s' message=%s>%s" %
-            [label, escape(klass), escape(msg).inspect, escape(bt.join("\n"))]
+            [label, escape(klass), escape(msg).inspect.gsub('\n', "&#13;&#10;"), escape(bt.join("\n"))]
           xml << "    </%s>" % label
         end
         xml << "  </testcase>"


### PR DESCRIPTION
Use XML character entities to properly display newlines in error messages.

`CGI.escapeHTML` escapes most characters properly, but leaves newlines as literal newlines, which are not being interpreted properly by CircleCI for failure reports. Update the output to a more compliant XML attribute output

Old:
![ci-old](https://cloud.githubusercontent.com/assets/993340/12493905/59a58c7c-c03c-11e5-992e-2eeb77a83943.png)

New:
![ci-new](https://cloud.githubusercontent.com/assets/993340/12493907/5d8253e8-c03c-11e5-8d46-4cde9d5bdf23.png)
