### PR TITLE
Prevent `filename too long` errors when test names are beyond 255 characters

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,11 +40,7 @@ task :test => %w[ci_cleanup test:one test:two]
 
 == INSTALL:
 
-<<<<<<< HEAD:README.md
-    $ gem install minitest-ci
-=======
 * gem install minitest-ci
->>>>>>> parent of 30e0766... Change README to markdown:README.rdoc
 
 == DEVELOPERS:
 

--- a/lib/minitest/ci.rb
+++ b/lib/minitest/ci.rb
@@ -54,7 +54,7 @@ module Minitest
 
       Dir.chdir report_dir do
         results.each do |name, resultz|
-          File.open "TEST-#{CGI.escape(name.to_s)}.xml", "w" do |f|
+          File.open "TEST-#{CGI.escape(name.to_s)}.xml"[0, 255], "w" do |f|
             f.puts generate_results name, resultz
           end
         end

--- a/test/minitest/test_ci.rb
+++ b/test/minitest/test_ci.rb
@@ -47,6 +47,12 @@ describe "spec/with::\"doublequotes\"" do
  end
 end
 
+describe 'spec/with::long_file_name' * 100 do
+  it 'will not throw filename too long errors' do
+    pass
+  end
+end
+
 # better way?
 $ci_io = StringIO.new
 Minitest::Ci.clean = false


### PR DESCRIPTION
Hey,

Please consider limiting HTML escaped filenames to 255 characters long as Linux systems usually only supports that much characters

Thanks!
