### PR TITLE
Minitest::CI should inherit Minitest::Reporter

### DIFF
--- a/lib/minitest/ci.rb
+++ b/lib/minitest/ci.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 require 'cgi'
 
 module Minitest
-  class Ci
+  class Ci < Reporter
 
     VERSION = '3.1.0'
 

--- a/minitest_ci.gemspec
+++ b/minitest_ci.gemspec
@@ -12,12 +12,13 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = '>= 1.3.6'
 
-  s.add_dependency 'minitest', '>= 5.0.6', '~> 5.9.0'
+  s.add_dependency 'minitest', '>= 5.0.6'
 
   s.add_development_dependency 'bundler', '~> 1.13'
   s.add_development_dependency 'rake', '~> 11.1.2'
   s.add_development_dependency 'nokogiri', '~> 1.5.0'
   s.add_development_dependency 'rdoc', '>= 2.4.2'
+  s.add_development_dependency 'json', '>= 2.0.0'
   s.add_development_dependency 'ZenTest'
 
   s.files = Dir.glob('lib/**/*.rb') + %w[README.rdoc]


### PR DESCRIPTION
This will solve issues like:
https://github.com/circleci/minitest-ci/pull/14/commits/64d6ea9027d99ee4be79041de978502310c7f04c

Which was caused by:
https://github.com/seattlerb/minitest/commit/c797bafa94838a98a9e41805df4517a7f0343d44

Also, we bumped development dependency on json to 2+ to work with Ruby 2.4+