### PR TITLE
Add timestamp to testsuite

### DIFF
--- a/lib/minitest/ci.rb
+++ b/lib/minitest/ci.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'cgi'
+require 'time'
 
 module Minitest
   class Ci < Reporter
@@ -70,6 +71,7 @@ module Minitest
 
     def generate_results name, results
       total_time = assertions = errors = failures = skips = 0
+      timestamp = Time.now.iso8601
       results.each do |result|
         total_time += result.time
         assertions += result.assertions
@@ -88,8 +90,8 @@ module Minitest
       xml = []
 
       xml << '<?xml version="1.0" encoding="UTF-8"?>'
-      xml << "<testsuite time='%6f' skipped='%d' failures='%d' errors='%d' name=%p assertions='%d' tests='%d'>" %
-        [total_time, skips, failures, errors, escape(name), assertions, results.count]
+      xml << "<testsuite time='%6f' skipped='%d' failures='%d' errors='%d' name=%p assertions='%d' tests='%d' timestamp=%p>" %
+        [total_time, skips, failures, errors, escape(name), assertions, results.count, timestamp]
 
       results.each do |result|
         xml << "  <testcase time='%6f' file=%p name=%p assertions='%s'>" %

--- a/test/minitest/test_ci.rb
+++ b/test/minitest/test_ci.rb
@@ -72,6 +72,8 @@ class TestMinitest::TestCi < Minitest::Test
   end
 
   def setup
+    @timestamp = Time.now
+
     file = "test/reports/TEST-MockTestSuite.xml"
     @file = File.read file
     @doc = Nokogiri.parse @file
@@ -85,6 +87,16 @@ class TestMinitest::TestCi < Minitest::Test
     assert_equal "3", @doc['assertions']
     assert_equal "7", @doc['tests']
     assert_equal "MockTestSuite", @doc['name']
+  end
+
+  def test_testsuite_sets_timestamp
+    parsed_time = Time.parse(@doc['timestamp'])
+    assert parsed_time.between?(@timestamp-5, @timestamp+5)
+  end
+
+  def test_testsuite_timestamp_format
+    iso_8061_format = %r{\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}}
+    assert_match iso_8061_format, @doc['timestamp']
   end
 
   def test_testcase_count


### PR DESCRIPTION
It would be helpful to know when the suite was run.

This conforms with the spec documented here: http://windyroad.com.au/dl/Open%20Source/JUnit.xsd