### PR TITLE
Use digest sha1 for report filenames

### DIFF
--- a/lib/minitest/ci.rb
+++ b/lib/minitest/ci.rb
@@ -132,7 +132,7 @@ module Minitest
     end
 
     def report_name(name)
-      "TEST-#{CGI.escape(name.to_s.gsub(/\W+/, '_'))}.xml"[0, 255]
+      "TEST-#{Digest::SHA1.hexdigest(CGI.escape(name.to_s.gsub(/\W+/, '_')))}.xml"
     end
   end
 end


### PR DESCRIPTION
The way of building filename can lead to very long filenames. We could use `Digest::SHA1.hexdigest` to keep these filenames short.

It also makes sure that the filename ends with the right extension as `"#{string}.xml"[0, 255]` would strip away the extension with a string longer than 251.