### PR TITLE
Add report_name option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -80,6 +80,18 @@ Alternatively, you can add the following code to your test runner setup:
     end
     task :test => %w[ci_cleanup test:one test:two]
 
+To configure report filename, use the `report_name` option like
+
+    Minitest::Ci.new $ci_io, { :report_name => :sha1 }
+
+or like
+
+    machine:
+      environment:
+        TESTOPTS: "--report-name=sha1"
+
+Supported options are: `:test_name` (default), `:sha1`, or a `Proc` (not supported through ENV var)
+
 == REQUIREMENTS:
 
 * Minitest > version 5

--- a/lib/minitest/ci.rb
+++ b/lib/minitest/ci.rb
@@ -132,7 +132,18 @@ module Minitest
     end
 
     def report_name(name)
-      "TEST-#{CGI.escape(name.to_s.gsub(/\W+/, '_'))}.xml"[0, 255]
+      report_name_opt = options.fetch(:report_name, :test_name)
+      return report_name_opt.call(name) if report_name_opt.is_a? Proc
+      return sha1_report_name(name) if report_name_opt.to_sym == :sha1
+      test_name_report_name(name)
+    end
+
+    def sha1_report_name(name)
+      "TEST-#{Digest::SHA1.hexdigest(name.to_s)}.xml"
+    end
+
+    def test_name_report_name(name)
+      "TEST-#{CGI.escape(name.to_s.gsub(/\W+/, '_'))[0, 246]}.xml"
     end
   end
 end

--- a/lib/minitest/ci_plugin.rb
+++ b/lib/minitest/ci_plugin.rb
@@ -18,6 +18,10 @@ module Minitest
     opts.on "--working-dir DIR", "Set the working dir. Default to #{Ci.working_dir}" do |dir|
       options[:working_dir] = dir
     end
+
+    opts.on "--report-name REPORT_NAME_OPTION", "Set report name option. Default to :test_name" do |report_name_option|
+      options[:report_name] = report_name_option
+    end
   end
 
 end

--- a/test/minitest/test_options.rb
+++ b/test/minitest/test_options.rb
@@ -1,0 +1,63 @@
+require 'minitest/autorun'
+require 'minitest/ci'
+
+require 'stringio'
+
+class MockTestSha1ReportNameSuite < Minitest::Test
+  def test_pass
+    pass
+  end
+end
+
+describe 'report with this name should be transformed in sha1' do
+ it 'passes' do
+   pass
+ end
+end
+
+$ci_io = StringIO.new
+Minitest::Ci.clean = false
+
+# setup test files
+reporter = Minitest::Ci.new $ci_io, { :report_name => :sha1 }
+reporter.start
+Minitest.__run reporter, {}
+reporter.report
+
+class TestMinitest; end
+class TestMinitest::TestOptions < Minitest::Test
+  def test_filename_is_sha1_digest
+    sha1 = Digest::SHA1.hexdigest("spec with this name should be transformed in sha1")
+    assert File.exist? "test/reports/TEST-#{sha1}.xml"
+  end
+end
+
+class MockTestProcReportNameSuite < Minitest::Test
+  def test_pass
+    pass
+  end
+end
+
+describe 'report with this name should be reversed' do
+ it 'passes' do
+   pass
+ end
+end
+
+$ci_io = StringIO.new
+Minitest::Ci.clean = false
+
+# setup test files
+reporter = Minitest::Ci.new $ci_io, { :report_name => -> (name) { "TEST-#{CGI.escape(name.to_s.gsub(/\W+/, '_').reverse)[0, 246]}.xml" } }
+reporter.start
+Minitest.__run reporter, {}
+reporter.report
+
+# Minitest::Runnable.reset
+
+class TestMinitest; end
+class TestMinitest::TestOptions < Minitest::Test
+  def test_filename_is_from_given_proc
+    assert File.exist? "test/reports/TEST-desrever_eb_dluohs_eman_siht_htiw_troper.xml"
+  end
+end


### PR DESCRIPTION
- [x] Add `report_name` option accepting `:sha1`, `:test_name` (default) or a `Proc`
- [x] Add a `sha1_report_name`
- [x] Fix test name based report name to always include `.xml`
- [ ] Supports configuration report_name option through ENV variable definition
- [x] Add documentation for option

Related to first attempt #19 