### PR TITLE
Minitest fixes

### DIFF
--- a/lib/minitest/ci_plugin.rb
+++ b/lib/minitest/ci_plugin.rb
@@ -83,7 +83,8 @@ module Minitest
     end
 
     def record result
-      results[result.class] << result
+      key = result.respond_to?(:klass) ? result.klass : result.class
+      results[key] << result
     end
 
     ##
@@ -132,7 +133,11 @@ module Minitest
         [total_time, skips, failures, errors, escape(name), assertions, results.count, timestamp]
 
       results.each do |result|
-        location = result.method(result.name).source_location[0].gsub(base, '')
+        location = if result.respond_to? :source_location then
+                     result.source_location
+                   else
+                     result.method(result.name).source_location
+                   end[0].gsub(base, '')
         xml << "  <testcase time='%6f' file=%p name=%p assertions='%s'>" %
           [result.time, escape(location), escape(result.name), result.assertions]
         if failure = result.failure

--- a/lib/minitest/ci_plugin.rb
+++ b/lib/minitest/ci_plugin.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 require 'cgi'
 require 'time'
+require 'digest'
 
 module Minitest
   def self.plugin_ci_options opts, options

--- a/lib/minitest/ci_plugin.rb
+++ b/lib/minitest/ci_plugin.rb
@@ -132,8 +132,9 @@ module Minitest
         [total_time, skips, failures, errors, escape(name), assertions, results.count, timestamp]
 
       results.each do |result|
+        location = result.method(result.name).source_location[0].gsub(base, '')
         xml << "  <testcase time='%6f' file=%p name=%p assertions='%s'>" %
-          [result.time, escape(result.method(result.name).source_location[0].gsub(base, '')), escape(result.name), result.assertions]
+          [result.time, escape(location), escape(result.name), result.assertions]
         if failure = result.failure
           label = failure.result_label.downcase
 


### PR DESCRIPTION
This includes a fix for minitest-ci to be able to simply run tests at all, but also includes fixes for upcoming changes to minitest. 5.11.0 is going to have some internals change that you depend on. This addresses that in a way that is compatible with current versions.